### PR TITLE
Add Chinese UI localization, Chinese README, and Zotero 9 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Open PDF
 
 English | [简体中文](README.zh-CN.md)
 
-Install by downloading the [latest version](https://github.com/retorquere/zotero-open-pdf/releases/latest). Compatible with Zotero 6 and 7.
+Install by downloading the [latest version](https://github.com/retorquere/zotero-open-pdf/releases/latest). Compatible with Zotero 7, 8, and 9.
 
 Zotero allows you to set a default for opening PDFs from Zotero:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Open PDF
 =================
 
+English | [简体中文](README.zh-CN.md)
+
 Install by downloading the [latest version](https://github.com/retorquere/zotero-open-pdf/releases/latest). Compatible with Zotero 6 and 7.
 
 Zotero allows you to set a default for opening PDFs from Zotero:
@@ -12,6 +14,10 @@ This plugin adds two things:
 
 * adds an option to the right-click menu of items to open PDFs with opposite of what you have configured in Zotero (so open with system PDF viewer if you have configured Zotero to open with the internal editor, and vice versa
 * allows you to add extra entries for your own PDF viewers/editor of choice
+
+The menu language follows Zotero's UI language. If you want to override it manually, add a new String entry in the config editor:
+
+`extensions.zotero.alt-open.locale` = `en` or `zh`
 
 To add your own, go into the Zotero preferences, tab Advanced, and open the config editor (You will be warned that you can break things. Don't break things). Then right-click and add a new String entry. The key must start with `extensions.zotero.alt-open.{pdf|snapshot|epub}.with.`, add any name you want after it, eg `extensions.zotero.alt-open.pdf.with.skim`, and as the value enter the command line needed to start the app, giving `@pdf` as a parameter where the filename must go. this could eg be
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@ Open PDF
 
 [English](README.md) | 简体中文
 
-通过下载[最新版本](https://github.com/retorquere/zotero-open-pdf/releases/latest)安装。兼容 Zotero 6 和 7。
+通过下载[最新版本](https://github.com/retorquere/zotero-open-pdf/releases/latest)安装。兼容 Zotero 7、8 和 9。
 
 Zotero 自己可以设置 PDF 的默认打开方式：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,63 @@
+Open PDF
+=================
+
+[English](README.md) | 简体中文
+
+通过下载[最新版本](https://github.com/retorquere/zotero-open-pdf/releases/latest)安装。兼容 Zotero 6 和 7。
+
+Zotero 自己可以设置 PDF 的默认打开方式：
+
+* 用系统 PDF 阅读器打开
+* 用 Zotero 内置 PDF 阅读器打开
+
+这个插件主要补了两件事：
+
+* 在条目右键菜单里增加一个“反向打开”的入口。比如你平时默认用 Zotero 内置阅读器打开，这里就能直接改用系统阅读器打开；反过来也一样
+* 允许你把自己常用的 PDF 阅读器或编辑器加进菜单
+
+菜单语言默认跟随 Zotero 当前界面语言。如果想手动覆盖，可以在配置编辑器里新增字符串项：
+
+`extensions.zotero.alt-open.locale` = `en` 或 `zh`
+
+如果要加自定义打开方式，进入 Zotero 设置里的“高级”，打开配置编辑器。然后新建一个字符串项，键名要以 `extensions.zotero.alt-open.{pdf|snapshot|epub}.with.` 开头，后面名字可以自己定，比如 `extensions.zotero.alt-open.pdf.with.skim`。值里填写启动程序需要的命令行，并在文件路径位置写 `@pdf`。例如：
+
+`extensions.zotero.alt-open.pdf.with.preview` = `/usr/bin/open -a Preview @pdf`
+
+这样菜单里就会多出一个对应的打开项。如果想自定义菜单文字，可以把显示名称写在前面的方括号里：
+
+`extensions.zotero.alt-open.pdf.with.skim` = `[Open with Skim]/usr/bin/open -a Skim @pdf`
+
+如果可执行文件路径里有空格，需要用引号包起来。比如在 Windows 上用 Edge 打开 PDF：
+
+`extensions.zotero.alt-open.pdf.with.edge` = `"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" @pdf`
+
+复杂一点的例子是通过 Chrome 扩展打开 PDF，比如 Acrobat 扩展：
+
+`extensions.zotero.alt-open.pdf.with.chrome-acrobat` = `"C:\Program Files\Google\Chrome\Application\chrome.exe" "chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/file:///@pdf"`
+
+这里的 `efaidnbmnnnibpcajpcglclefindmkaj` 是 Acrobat 扩展的 ID。要让扩展能读取 `file:///` 协议，需要在“管理扩展程序”页面打开“允许访问文件网址”。
+
+**新增菜单项后，需要重启插件才会生效。**
+
+有些程序（例如 sioyek）可能会表现得更像命令行程序，启动后会变成 Zotero 的子进程，而不是独立进程，结果就是行为不符合预期。
+
+在 Windows 上，可以用 `start` 命令把它作为独立进程启动。
+
+`extensions.zotero.alt-open.pdf.with.sioyek` = `"C:\Windows\System32\cmd.exe" /c start "" "C:\Users\user\scoop\apps\sioyek\2.0.0\sioyek.exe" --new-window @pdf`
+
+**注意：**
+
+**插件不会去系统 PATH 里查找程序，你需要填写完整的可执行文件路径。路径里如果有空格或反斜杠 `\`，要用英文双引号包起来。**
+
+
+# 警告
+
+在 Zotero 外部修改 PDF（例如删除、移动、旋转页面），可能会让 Zotero 里的批注和 PDF 内容出现不一致。
+
+如果只是旋转或删除单页，可以直接在 Zotero PDF 阅读器侧边栏的缩略图页签里操作，这样是安全的。相关说明可以看 Zotero 的支持文档：[using an external PDF reader](https://www.zotero.org/support/kb/annotations_in_database)（使用外部 PDF 阅读器）。
+
+# 支持说明，请先看
+
+作者能投入的时间很有限，所以只处理最新版相关的问题和支持请求。
+
+如果你要提交问题，请把自己当前使用的版本号一并写上。等作者看到问题时，最新版本可能已经更新了，你可能需要先升级，再确认问题是否还存在。

--- a/lib.ts
+++ b/lib.ts
@@ -16,6 +16,76 @@ import { log } from './lib/log'
 log('lib loading')
 
 const Kinds = ['PDF', 'Snapshot', 'ePub']
+const KindLabels = {
+  en: {
+    pdf: 'PDF',
+    snapshot: 'Snapshot',
+    epub: 'ePub',
+  },
+  zh: {
+    pdf: 'PDF',
+    snapshot: '快照',
+    epub: 'ePub',
+  },
+} as const
+
+const Messages = {
+  en: {
+    headline: 'Open PDF',
+    openFailed: 'Opening failed',
+    openMenu: 'Open {kind}',
+    openWith: 'Open with {name}',
+    notFound: '{path} not found',
+    notRunnable: '{path} is not runnable',
+  },
+  zh: {
+    headline: '打开附件',
+    openFailed: '打开失败',
+    openMenu: '打开 {kind}',
+    openWith: '使用 {name} 打开',
+    notFound: '未找到 {path}',
+    notRunnable: '{path} 无法运行',
+  },
+} as const
+
+type Locale = keyof typeof Messages
+
+function normalizeLocale(locale: string): Locale | null {
+  const normalized = locale.trim().toLowerCase()
+  if (!normalized) return null
+  if (normalized === 'en' || normalized.startsWith('en-')) return 'en'
+  if (normalized === 'zh' || normalized.startsWith('zh-')) return 'zh'
+  return null
+}
+
+function locale(): Locale {
+  const override = normalizeLocale(`${Zotero.Prefs.get('extensions.zotero.alt-open.locale', true) || ''}`)
+  if (override) return override
+
+  for (const source of [
+    `${Zotero.locale || ''}`,
+    `${Services?.locale?.requestedLocale || ''}`,
+    `${Services?.locale?.appLocaleAsBCP47 || ''}`,
+    `${Services?.locale?.lastFallbackLocale || ''}`,
+  ]) {
+    const detected = normalizeLocale(source)
+    if (detected) return detected
+  }
+
+  return 'en'
+}
+
+function t(key: keyof typeof Messages.en, vars: Record<string, string> = {}): string {
+  let text: string = Messages[locale()][key]
+  for (const [name, value] of Object.entries(vars)) {
+    text = text.replace(`{${name}}`, value)
+  }
+  return text
+}
+
+function kindLabel(kind: string): string {
+  return KindLabels[locale()][kind] || kind
+}
 
 type Opener = { label: string; cmdline: string }
 function getOpener(opener: string): Opener {
@@ -24,7 +94,10 @@ function getOpener(opener: string): Opener {
   if (!cmdline) return { label: '', cmdline: '' }
   const m = cmdline.match(/^\[(.+?)\](.+)/)
   if (m) return { label: m[1], cmdline: m[2] }
-  return { label: `Open with ${opener.replace(/^extensions\.zotero\.alt-open\.[a-z]+\.with\./, '')}`, cmdline }
+  return {
+    label: t('openWith', { name: opener.replace(/^extensions\.zotero\.alt-open\.[a-z]+\.with\./, '') }),
+    cmdline,
+  }
 }
 
 function exec(exe: string, args: string[] = []): void {
@@ -32,11 +105,11 @@ function exec(exe: string, args: string[] = []): void {
 
   const cmd = Zotero.File.pathToFile(exe)
   if (!cmd.exists()) {
-    flash('opening PDF failed', `${exe} not found`)
+    flash(t('openFailed'), t('notFound', { path: exe }))
     return
   }
   if (!cmd.isExecutable()) {
-    flash('opening PDF failed', `${exe} is not runnable`)
+    flash(t('openFailed'), t('notRunnable', { path: exe }))
     return
   }
 
@@ -50,10 +123,8 @@ function flash(title: string, body?: string, timeout = 8): void {
   try {
     log(`flash: ${JSON.stringify({ title, body })}`)
     const pw = new Zotero.ProgressWindow()
-    pw.changeHeadline(`open-pdf ${title}`)
-    if (!body) body = title
-    if (Array.isArray(body)) body = body.join('\n')
-    pw.addDescription(body)
+    pw.changeHeadline(t('headline'))
+    pw.addDescription(body ? `${title}\n${body}` : title)
     pw.show()
     pw.startCloseTimer(timeout * 1000)
   }
@@ -169,7 +240,7 @@ export class ZoteroAltOpenPDF {
         log(`chrome://zotero-open-pdf/content/${kind}.svg`)
         Menu.register('item', {
           tag: 'menu',
-          label: `Open ${Kind}`,
+          label: t('openMenu', { kind: kindLabel(kind) }),
           icon: `chrome://zotero-open-pdf/content/${kind}.svg`,
           isHidden: async (elem, ev) => {
             log(`menu activated: selected ${kind} = ${await selectedAttachment(kind)}`)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "updateLink": "https://github.com/retorquere/zotero-open-pdf/releases/download/v{version}/zotero-open-pdf-{version}.xpi",
     "releaseURL": "https://github.com/retorquere/zotero-open-pdf/releases/download/release/",
     "bootstrapped": true,
-    "minVersion": "7.0"
+    "minVersion": "7.0",
+    "maxVersion": "9.*"
   },
   "devDependencies": {
     "jsdom": "^27.4.0",


### PR DESCRIPTION
  ## Summary

  This PR makes a minimal set of changes to improve usability for Chinese 
  users and restore compatibility with Zotero 9.

  Changes included:
  - add Chinese UI labels for menu items and error messages
  - auto-detect the Zotero UI locale and switch between English and       
  Chinese
  - allow manual locale override with `extensions.zotero.alt-open.locale` 
  - add a Simplified Chinese README and link it from the English README   
  - update the add-on manifest to support Zotero 9 (`strict_max_version:  
  9.*`)

  ## Notes

  The localization layer is intentionally small and only affects user-    
  facing strings. Core open-file behavior is unchanged.

  Manual locale override values:
  - `en`
  - `zh`

  ## Testing

  Tested locally with:
  - `npx tsc --noEmit`
  - `node esbuild.js`
  - packaging the add-on and verifying the generated `manifest.json`      
  contains `strict_max_version: 9.*`